### PR TITLE
Add option parameter to fastify interface

### DIFF
--- a/fastify-auth.d.ts
+++ b/fastify-auth.d.ts
@@ -32,7 +32,10 @@ declare module 'fastify' {
     HttpResponse = ServerResponse
   > {
     auth(
-      functions: fastifyAuth.AuthFunction[]
+      functions: fastifyAuth.AuthFunction[],
+      options?: {
+        relation: 'and' | 'or'
+      }
     ): FastifyMiddleware<
       HttpServer,
       HttpRequest,

--- a/types.test.ts
+++ b/types.test.ts
@@ -21,4 +21,20 @@ app.register(fastifyAuth).after((err) => {
       done();
     },
   ], {relation: 'or'});
+  app.auth([
+    (
+      _request: fastify.FastifyRequest<
+        http.IncomingMessage,
+        fastify.DefaultQuery,
+        fastify.DefaultParams,
+        fastify.DefaultHeaders,
+        any
+      >,
+      _reply: fastify.FastifyReply<http.ServerResponse>,
+      done
+    ) => {
+      done(new Error());
+      done();
+    },
+  ]);
 });

--- a/types.test.ts
+++ b/types.test.ts
@@ -20,5 +20,5 @@ app.register(fastifyAuth).after((err) => {
       done(new Error());
       done();
     },
-  ]);
+  ], {relation: 'or'});
 });


### PR DESCRIPTION
Adds the option parameter to the `fastify.auth` function. This allows Typescript users to change the relation between the auth functions from `or` to `and`. 

This pull request solves https://github.com/fastify/fastify-auth/issues/59
