### PR TITLE
fix wrong status when run all

### DIFF
--- a/fastify-auth.js
+++ b/fastify-auth.js
@@ -68,10 +68,6 @@ function auth (functions, opts) {
       var func = that.functions[that.i++]
 
       if (!func) {
-        if (err && (!that.reply.res.statusCode || that.reply.res.statusCode < 400)) {
-          that.reply.code(401)
-        }
-
         that.completeAuth(err)
         return
       }
@@ -95,7 +91,6 @@ function auth (functions, opts) {
         return that.completeAuth()
       } else {
         if (err) {
-          that.reply.code(401)
           return that.completeAuth(err)
         }
 
@@ -113,6 +108,9 @@ function auth (functions, opts) {
         return that.nextAuth(err)
       }
 
+      if (that.firstResult && (!that.reply.res.statusCode || that.reply.res.statusCode < 400)) {
+        that.reply.code(401)
+      }
       that.done(that.firstResult)
       instance.release(that)
     }

--- a/test/example-composited.test.js
+++ b/test/example-composited.test.js
@@ -339,6 +339,31 @@ test('Check run all fail line with OR', t => {
   })
 })
 
+test('Ignore last status', t => {
+  t.plan(5)
+
+  const fastify = build()
+
+  fastify.after(() => {
+    fastify.route({
+      method: 'GET',
+      url: '/run-all-status',
+      preHandler: fastify.auth([
+        (req, reply, done) => { t.pass('executed 1'); done() },
+        (req, reply, done) => { t.pass('executed 2'); done(new Error('last')) }
+      ], { relation: 'or', run: 'all' }),
+      handler: (req, reply) => { reply.send({ hello: 'world' }) }
+    })
+  })
+
+  fastify.inject('/run-all-status', (err, res) => {
+    t.error(err)
+    t.equals(res.statusCode, 200)
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})
+
 test('Or Relation run all', t => {
   t.plan(2)
 


### PR DESCRIPTION
Running the `or` relation with `run` all will preserve the status code of the last executed auth function.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
