### PR TITLE
fix clean code by user

### DIFF
--- a/fastify-auth.js
+++ b/fastify-auth.js
@@ -85,9 +85,6 @@ function auth (functions, opts) {
           return that.nextAuth(err)
         }
 
-        if (that.i > 0 && that.reply.res.statusCode && that.reply.res.statusCode >= 400) {
-          that.reply.code(200)
-        }
         return that.completeAuth()
       } else {
         if (err) {
@@ -110,7 +107,10 @@ function auth (functions, opts) {
 
       if (that.firstResult && (!that.reply.res.statusCode || that.reply.res.statusCode < 400)) {
         that.reply.code(401)
+      } else if (!that.firstResult && that.reply.res.statusCode && that.reply.res.statusCode >= 400) {
+        that.reply.code(200)
       }
+
       that.done(that.firstResult)
       instance.release(that)
     }

--- a/test/example-composited.test.js
+++ b/test/example-composited.test.js
@@ -423,3 +423,28 @@ test('And Relation run all', t => {
     })
   })
 })
+
+test('Clean status code settle by user', t => {
+  t.plan(5)
+
+  const fastify = build()
+
+  fastify.after(() => {
+    fastify.route({
+      method: 'GET',
+      url: '/run-all-status',
+      preHandler: fastify.auth([
+        (req, reply, done) => { t.pass('executed 1'); done() },
+        (req, reply, done) => { t.pass('executed 2'); reply.code(400); done(new Error('last')) }
+      ], { relation: 'or', run: 'all' }),
+      handler: (req, reply) => { reply.send({ hello: 'world' }) }
+    })
+  })
+
+  fastify.inject('/run-all-status', (err, res) => {
+    t.error(err)
+    t.equals(res.statusCode, 200)
+    var payload = JSON.parse(res.payload)
+    t.deepEqual(payload, { hello: 'world' })
+  })
+})


### PR DESCRIPTION
Sorry for another PR 😅

If the user sets the status code by yourself in one of the auth handlers, the status code is not cleaned when a successful auth is found in case the relation is `or`.

I hope to have covered all the cases..

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
