### PR TITLE
add context type for FastifyAuthFunction

### DIFF
--- a/auth.d.ts
+++ b/auth.d.ts
@@ -1,6 +1,7 @@
-import { FastifyPlugin, FastifyRequest, FastifyReply, preHandlerHookHandler } from 'fastify';
+import { FastifyPlugin, FastifyRequest, FastifyReply, preHandlerHookHandler, FastifyInstance } from 'fastify';
 
 export type FastifyAuthFunction = (
+  this: FastifyInstance,
   request: FastifyRequest,
   reply: FastifyReply,
   done: (error?: Error) => void

--- a/test/auth.test-d.ts
+++ b/test/auth.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyRequest, FastifyReply, preHandlerHookHandler } from 'fastify';
+import fastify, { FastifyRequest, FastifyReply, preHandlerHookHandler, FastifyInstance } from 'fastify';
 import fastifyAuth from '../auth'
 import { expectType } from 'tsd';
 
@@ -26,6 +26,11 @@ app.register(fastifyAuth).after((err) => {
 			expectType<FastifyRequest>(request)
 			expectType<FastifyReply>(reply)
 			expectType<Done>(done)
+    },
+  ]);
+  app.auth([
+    function (request, reply, done) {
+      expectType<FastifyInstance>(this)
     },
   ]);
   const auth = app.auth([(request, reply, done) => {}]);


### PR DESCRIPTION
Sets the context (`this`) so that you can access the fastify instance from within an auth function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
