### PR TITLE
chore: clearer explanation on the done function usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fastify
 ```
 _For more examples, please check [`example-composited.js`](example-composited.js)_
 
-This plugin support `callback` and `Promise` returned by the functions. Note that an `async` function does not have to use the `done` parameter:
+This plugin support `callback` and `Promise` returned by the functions. Note that an `async` function **does not have** to call the `done` parameter, otherwise the route handler to which the auth methods are linked to might be called multiple times:
 ```js
 fastify
   .decorate('asyncVerifyJWTandLevel', async function (request, reply) {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fastify
 ```
 _For more examples, please check [`example-composited.js`](example-composited.js)_
 
-This plugin support `callback` and `Promise` returned by the functions. Note that an `async` function **does not have** to call the `done` parameter, otherwise the route handler to which the auth methods are linked to might be called multiple times:
+This plugin support `callback` and `Promise` returned by the functions. Note that an `async` function **does not have** to call the `done` parameter, otherwise the route handler to which the auth methods are linked to [might be called multiple times](https://www.fastify.io/docs/latest/Hooks/#respond-to-a-request-from-a-hook):
 ```js
 fastify
   .decorate('asyncVerifyJWTandLevel', async function (request, reply) {


### PR DESCRIPTION
make clear why one either defines the auth method as a promise and return or doesn't define the auth method as a promise and calls the done method

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
