### PR TITLE
feat: more flexible composited authenication

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,40 @@ fastify
   })
 ```
 
+If you need composited authentication, such as verifying user account passwords and levels or meeting VIP eligibility criteria. e.g. [(verifyUserPassword `and` verifyLevel) `or` (verifyVIP)]
+```js
+fastify
+  .decorate('verifyUserPassword', function (request, reply, done) {
+    // your validation logic
+    done() // pass an error if the authentication fails
+  })
+  .decorate('verifyLevel', function (request, reply, done) {
+    // your validation logic
+    done() // pass an error if the authentication fails
+  })
+  .decorate('verifyVIP', function (request, reply, done) {
+    // your validation logic
+    done() // pass an error if the authentication fails
+  })
+  .register(require('@fastify/auth'))
+  .after(() => {
+    fastify.route({
+      method: 'POST',
+      url: '/auth-multiple',
+      preHandler: fastify.auth([
+        [fastify.verifyUserPassword, fastify.verifyLevel], // The arrays within an array always have an AND relationship.
+        fastify.verifyVIP
+      ], {
+        relation: 'or' // default relation
+      }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+  })
+```
+
 You can use the `defaultRelation` option while registering the plugin, to change the default `relation`:
 ```js
 fastify.register(require('@fastify/auth'), { defaultRelation: 'and'} )

--- a/auth.d.ts
+++ b/auth.d.ts
@@ -3,7 +3,7 @@ import { ContextConfigDefault, RouteGenericInterface, FastifyInstance, FastifyPl
 declare module 'fastify' {
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
     auth(
-      functions: fastifyAuth.FastifyAuthFunction[],
+      functions: fastifyAuth.FastifyAuthFunction[] | (fastifyAuth.FastifyAuthFunction | fastifyAuth.FastifyAuthFunction[])[],
       options?: {
         relation?: 'and' | 'or',
         run?: 'all'

--- a/auth.js
+++ b/auth.js
@@ -39,7 +39,13 @@ function auth (pluginOptions) {
 
     /* eslint-disable-next-line no-var */
     for (var i = 0; i < functions.length; i++) {
-      functions[i] = functions[i].bind(this)
+      if (functions[i] instanceof Array) {
+        for (let j = 0; j < functions[i].length; j++) {
+          functions[i][j] = functions[i][j].bind(this)
+        }
+      } else {
+        functions[i] = [functions[i].bind(this)]
+      }
     }
 
     const instance = reusify(Auth)
@@ -53,8 +59,9 @@ function auth (pluginOptions) {
       obj.functions = this.functions
       obj.options = this.options
       obj.i = 0
-      obj.start = true
+      obj.j = 0
       obj.firstResult = null
+      obj.sufficient = false
 
       obj.nextAuth()
     }
@@ -64,21 +71,22 @@ function auth (pluginOptions) {
     function Auth () {
       this.next = null
       this.i = 0
-      this.start = true
+      this.j = 0
       this.functions = []
       this.options = {}
       this.request = null
       this.reply = null
       this.done = null
       this.firstResult = null
+      this.sufficient = false
 
       const that = this
 
       this.nextAuth = function nextAuth (err) {
-        const func = that.functions[that.i++]
+        const func = that.functions[that.i][that.j++]
 
         if (!func) {
-          that.completeAuth(err)
+          that.completeAuthArray(err)
           return
         }
 
@@ -94,31 +102,48 @@ function auth (pluginOptions) {
       }
 
       this.onAuth = function onAuth (err, results) {
-        if (that.options.relation === 'or') {
-          if (err) {
-            return that.nextAuth(err)
-          }
-
-          return that.completeAuth()
-        } else {
-          if (err) {
-            return that.completeAuth(err)
-          }
-
-          return that.nextAuth(err)
+        if (err) {
+          return that.completeAuthArray(err)
         }
+
+        return that.nextAuth(err)
       }
 
-      this.completeAuth = function (err) {
-        if (that.start) {
-          that.start = false
-          that.firstResult = err
+      this.completeAuthArray = function (err) {
+        if (err) {
+          if (that.options.relation === 'and') {
+            if (that.options.run === 'all') {
+              that.firstResult = that.firstResult ?? err
+            } else {
+              that.firstResult = err
+              this.completeAuth()
+              return
+            }
+          } else {
+            that.firstResult = that.sufficient ? null : err
+          }
+        } else {
+          if (that.options.relation === 'or') {
+            that.sufficient = true
+            that.firstResult = null
+
+            if (that.options.run !== 'all') {
+              this.completeAuth()
+              return
+            }
+          }
         }
 
-        if (that.options.run === 'all' && that.i < that.functions.length) {
+        if (that.i < that.functions.length - 1) {
+          that.i += 1
+          that.j = 0
           return that.nextAuth(err)
         }
 
+        this.completeAuth()
+      }
+
+      this.completeAuth = function () {
         if (that.firstResult && (!that.reply.raw.statusCode || that.reply.raw.statusCode < 400)) {
           that.reply.code(401)
         } else if (!that.firstResult && that.reply.raw.statusCode && that.reply.raw.statusCode >= 400) {

--- a/test/example-composited.js
+++ b/test/example-composited.js
@@ -70,8 +70,28 @@ function build (opts) {
 
     fastify.route({
       method: 'POST',
+      url: '/checkarrayand',
+      preHandler: fastify.auth([[fastify.verifyNumber], [fastify.verifyOdd]], { relation: 'and' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
       url: '/checkor',
       preHandler: fastify.auth([fastify.verifyOdd, fastify.verifyBig]),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/checkarrayor',
+      preHandler: fastify.auth([[fastify.verifyOdd], [fastify.verifyBig]]),
       handler: (req, reply) => {
         req.log.info('Auth route')
         reply.send({ hello: 'world' })
@@ -90,8 +110,48 @@ function build (opts) {
 
     fastify.route({
       method: 'POST',
+      url: '/singlearrayor',
+      preHandler: fastify.auth([[fastify.verifyOdd]]),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
       url: '/singleand',
       preHandler: fastify.auth([fastify.verifyOdd], { relation: 'and' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/singlearrayand',
+      preHandler: fastify.auth([[fastify.verifyOdd]], { relation: 'and' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/singlearraycheckand',
+      preHandler: fastify.auth([[fastify.verifyNumber, fastify.verifyOdd]]),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/checkarrayorsingle',
+      preHandler: fastify.auth([[fastify.verifyNumber, fastify.verifyOdd], fastify.verifyBig]),
       handler: (req, reply) => {
         req.log.info('Auth route')
         reply.send({ hello: 'world' })

--- a/test/example-composited.test.js
+++ b/test/example-composited.test.js
@@ -50,6 +50,42 @@ test('And Relation failed for single case', t => {
   })
 })
 
+test('And Relation sucess for single [Array] case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearrayand',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('And Relation failed for single [Array] case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearrayand',
+    payload: {
+      n: 10
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not odd',
+      statusCode: 401
+    })
+  })
+})
+
 test('Or Relation sucess for single case', t => {
   t.plan(2)
 
@@ -72,6 +108,42 @@ test('Or Relation failed for single case', t => {
   fastify.inject({
     method: 'POST',
     url: '/singleor',
+    payload: {
+      n: 10
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not odd',
+      statusCode: 401
+    })
+  })
+})
+
+test('Or Relation sucess for single [Array] case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearrayor',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('Or Relation failed for single [Array] case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearrayor',
     payload: {
       n: 10
     }
@@ -163,12 +235,46 @@ test('And Relation success', t => {
   })
 })
 
+test('[Array] notation And Relation success', t => {
+  t.plan(3)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayand',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+    t.equal(res.statusCode, 200)
+  })
+})
+
 test('Or Relation success under first case', t => {
   t.plan(3)
 
   fastify.inject({
     method: 'POST',
     url: '/checkor',
+    payload: {
+      n: 1
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+    t.equal(res.statusCode, 200)
+  })
+})
+
+test('[Array] notation Or Relation success under first case', t => {
+  t.plan(3)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayor',
     payload: {
       n: 1
     }
@@ -197,6 +303,23 @@ test('Or Relation success under second case', t => {
   })
 })
 
+test('[Array] notation Or Relation success under second case', t => {
+  t.plan(3)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayor',
+    payload: {
+      n: 200
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+    t.equal(res.statusCode, 200)
+  })
+})
+
 test('Or Relation failed for both case', t => {
   t.plan(2)
 
@@ -205,6 +328,114 @@ test('Or Relation failed for both case', t => {
     url: '/checkor',
     payload: {
       n: 90
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not big',
+      statusCode: 401
+    })
+  })
+})
+
+test('[Array] notation Or Relation failed for both case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayor',
+    payload: {
+      n: 90
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not big',
+      statusCode: 401
+    })
+  })
+})
+
+test('single [Array] And Relation sucess', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearraycheckand',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('single [Array] And Relation failed', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/singlearraycheckand',
+    payload: {
+      n: 10
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not odd',
+      statusCode: 401
+    })
+  })
+})
+
+test('[Array] notation & single case Or Relation sucess under first case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayorsingle',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('[Array] notation & single case Or Relation sucess under second case', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayorsingle',
+    payload: {
+      n: 1002
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('[Array] notation & single case Or Relation failed', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/checkarrayorsingle',
+    payload: {
+      n: 2
     }
   }, (err, res) => {
     t.error(err)


### PR DESCRIPTION
According to the current version, only a default relationship of either all `AND` or all `OR` can be set.

If I want to configure the following verification relationship:
[(verifyUserPassword `and` verifyLevel) `or` (verifyVIP)]

it cannot be configured.

This PR is intended to address more complex authorization scenarios in practice, including both AND and OR relationships.

I will treat it as a two-dimensional array where each element represents a verification method, and the second dimension of the array always has an `AND` relationship.

And it is backwards compatible with defaultRelation OR and AND.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)