### PR TITLE
feat: extend composite auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ fastify
   })
 ```
 
-If you need composited authentication, such as verifying user account passwords and levels or meeting VIP eligibility criteria. e.g. [(verifyUserPassword `and` verifyLevel) `or` (verifyVIP)]
+If you need composite authentication, such as verifying user account passwords and levels or meeting VIP eligibility criteria, you can use nested arrays.
+For example if you need the following logic: [(verifyUserPassword `and` verifyLevel) `or` (verifyVIP)], it can be achieved with the code below:
 ```js
 fastify
   .decorate('verifyUserPassword', function (request, reply, done) {
@@ -94,7 +95,7 @@ fastify
       method: 'POST',
       url: '/auth-multiple',
       preHandler: fastify.auth([
-        [fastify.verifyUserPassword, fastify.verifyLevel], // The arrays within an array always have an AND relationship.
+        [fastify.verifyUserPassword, fastify.verifyLevel], // The arrays within an array have the opposite relation to the main (default) relation.
         fastify.verifyVIP
       ], {
         relation: 'or' // default relation
@@ -106,6 +107,15 @@ fastify
     })
   })
 ```
+
+If the `relation` (`defaultRelation`) parameter is `and`, then the relation inside sub-arrays will be `or`.
+If the `relation` (`defaultRelation`) parameter is `or`, then the relation inside sub-arrays will be `and`.
+
+| auth code        | resulting logical expression           | 
+| ------------- |:-------------:| 
+| `fastify.auth([f1, f2, [f3, f4]], { relation: 'or' })`  | `f1 OR f2 OR (f3 AND f4)` | 
+| `fastify.auth([f1, f2, [f3, f4]], { relation: 'and' })` | `f1 AND f2 AND (f3 OR f4)` | 
+
 
 You can use the `defaultRelation` option while registering the plugin, to change the default `relation`:
 ```js

--- a/test/example-composited.js
+++ b/test/example-composited.js
@@ -12,6 +12,8 @@ function build (opts) {
   fastify.decorate('verifyNumber', verifyNumber)
   fastify.decorate('verifyOdd', verifyOdd)
   fastify.decorate('verifyBig', verifyBig)
+  fastify.decorate('verifyOddAsync', verifyOddAsync)
+  fastify.decorate('verifyBigAsync', verifyBigAsync)
 
   function verifyNumber (request, reply, done) {
     const n = request.body.n
@@ -49,6 +51,24 @@ function build (opts) {
     return done()
   }
 
+  function verifyOddAsync (request, reply) {
+    return new Promise((resolve, reject) => {
+      verifyOdd(request, reply, (err) => {
+        if (err) reject(err)
+        resolve()
+      })
+    })
+  }
+
+  function verifyBigAsync (request, reply) {
+    return new Promise((resolve, reject) => {
+      verifyBig(request, reply, (err) => {
+        if (err) reject(err)
+        resolve()
+      })
+    })
+  }
+
   function routes () {
     fastify.route({
       method: 'GET',
@@ -75,6 +95,84 @@ function build (opts) {
       handler: (req, reply) => {
         req.log.info('Auth route')
         reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-and',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOdd, fastify.verifyBig]], { relation: 'and' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-and-async',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOddAsync, fastify.verifyBigAsync]], { relation: 'and' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-and-run-all',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOdd, fastify.verifyBig]], { relation: 'and', run: 'all' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({
+          odd: req.odd,
+          big: req.big,
+          number: req.number
+        })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-or',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOdd, fastify.verifyBig]], { relation: 'or' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-two-sub-arrays-or',
+      preHandler: fastify.auth([[fastify.verifyBigAsync], [fastify.verifyOddAsync]], { relation: 'or' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-or-async',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOddAsync, fastify.verifyBigAsync]], { relation: 'or' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({ hello: 'world' })
+      }
+    })
+
+    fastify.route({
+      method: 'POST',
+      url: '/check-composite-or-run-all',
+      preHandler: fastify.auth([fastify.verifyNumber, [fastify.verifyOdd, fastify.verifyBig]], { relation: 'or', run: 'all' }),
+      handler: (req, reply) => {
+        req.log.info('Auth route')
+        reply.send({
+          odd: req.odd,
+          big: req.big,
+          number: req.number
+        })
       }
     })
 

--- a/test/example-composited.test.js
+++ b/test/example-composited.test.js
@@ -14,7 +14,7 @@ t.before(() => {
   fastify = build()
 })
 
-test('And Relation sucess for single case', t => {
+test('And Relation success for single case', t => {
   t.plan(2)
 
   fastify.inject({
@@ -86,7 +86,7 @@ test('And Relation failed for single [Array] case', t => {
   })
 })
 
-test('Or Relation sucess for single case', t => {
+test('Or Relation success for single case', t => {
   t.plan(2)
 
   fastify.inject({
@@ -122,7 +122,7 @@ test('Or Relation failed for single case', t => {
   })
 })
 
-test('Or Relation sucess for single [Array] case', t => {
+test('Or Relation success for single [Array] case', t => {
   t.plan(2)
 
   fastify.inject({
@@ -252,6 +252,80 @@ test('[Array] notation And Relation success', t => {
   })
 })
 
+test('And Relation with Or relation inside sub-array success', t => {
+  t.plan(3)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-and',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+    t.equal(res.statusCode, 200)
+  })
+})
+
+test('And Relation with Or relation inside sub-array failed', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-and',
+    payload: {
+      n: 4
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not big',
+      statusCode: 401
+    })
+  })
+})
+
+test('And Relation with Or relation inside sub-array with async functions success', t => {
+  t.plan(3)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-and-async',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+    t.equal(res.statusCode, 200)
+  })
+})
+
+test('And Relation with Or relation inside sub-array with async functions failed', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-and-async',
+    payload: {
+      n: 4
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not big',
+      statusCode: 401
+    })
+  })
+})
+
 test('Or Relation success under first case', t => {
   t.plan(3)
 
@@ -360,7 +434,7 @@ test('[Array] notation Or Relation failed for both case', t => {
   })
 })
 
-test('single [Array] And Relation sucess', t => {
+test('single [Array] And Relation success', t => {
   t.plan(2)
 
   fastify.inject({
@@ -396,7 +470,43 @@ test('single [Array] And Relation failed', t => {
   })
 })
 
-test('[Array] notation & single case Or Relation sucess under first case', t => {
+test('Two sub-arrays Or Relation success', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-two-sub-arrays-or',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, { hello: 'world' })
+  })
+})
+
+test('Two sub-arrays Or Relation fail', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-two-sub-arrays-or',
+    payload: {
+      n: 4
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      error: 'Unauthorized',
+      message: '`n` is not odd',
+      statusCode: 401
+    })
+  })
+})
+
+test('[Array] notation & single case Or Relation success under first case', t => {
   t.plan(2)
 
   fastify.inject({
@@ -412,7 +522,7 @@ test('[Array] notation & single case Or Relation sucess under first case', t => 
   })
 })
 
-test('[Array] notation & single case Or Relation sucess under second case', t => {
+test('[Array] notation & single case Or Relation success under second case', t => {
   t.plan(2)
 
   fastify.inject({
@@ -444,6 +554,46 @@ test('[Array] notation & single case Or Relation failed', t => {
       error: 'Unauthorized',
       message: '`n` is not big',
       statusCode: 401
+    })
+  })
+})
+
+test('And Relation with Or relation inside sub-array with run: all', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-and-run-all',
+    payload: {
+      n: 11
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      odd: true,
+      big: false,
+      number: true
+    })
+  })
+})
+
+test('Or Relation with And relation inside sub-array with run: all', t => {
+  t.plan(2)
+
+  fastify.inject({
+    method: 'POST',
+    url: '/check-composite-or-run-all',
+    payload: {
+      n: 110
+    }
+  }, (err, res) => {
+    t.error(err)
+    const payload = JSON.parse(res.payload)
+    t.same(payload, {
+      odd: false,
+      big: true,
+      number: true
     })
   })
 })
@@ -631,6 +781,15 @@ test('Or Relation run all fail', t => {
       statusCode: 401
     })
   })
+})
+
+test('Nested sub-arrays not supported', t => {
+  t.plan(1)
+  try {
+    fastify.auth([[fastify.verifyBig, [fastify.verifyNumber]]])
+  } catch (err) {
+    t.same(err.message, 'Nesting sub-arrays is not supported')
+  }
 })
 
 test('And Relation run all', t => {


### PR DESCRIPTION
This PR addresses Issue #216: Extending composite authentication to allow nesting auth arrays with both `and` and `or` relations.

If the `relation` (`defaultRelation`) parameter is `and`, then the relation inside sub-arrays will be `or`.
If the `relation` (`defaultRelation`) parameter is `or`, then the relation inside sub-arrays will be `and`.

| auth code        | resulting logical expression           | 
| ------------- |:-------------:| 
| `fastify.auth([f1, f2, [f3, f4]], { relation: 'or' })`  | `f1 OR f2 OR (f3 AND f4)` | 
| `fastify.auth([f1, f2, [f3, f4]], { relation: 'and' })` | `f1 AND f2 AND (f3 OR f4)` | 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
