### PR TITLE
docs(readme): consider `preParsing` hook safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ The difference between the two approaches is that using the route-level `preHand
 
 ## Security Considerations
 
-### `onRequest` vs. `preHandler` hook
+### Hook selection
 
-The main difference between the `onRequest` and `preHandler` stages of the [Fastify Lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/) is that the body payload is not parsed in the `onRequest` stage. Parsing the body can be a potential security risk, as it can be used for denial of service (DoS) attacks. Therefore, it is recommended to avoid parsing the body for unauthorized access.
+In the [Fastify Lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/), the `onRequest` and `preParsing` stages do not parse the payload, unlike the `preHandler` stage. Parsing the body can be a potential security risk, as it can be used for denial of service (DoS) attacks. Therefore, it is recommended to avoid parsing the body for unauthorized access.
 
-Using the `@fastify/auth` plugin in the `preHandler` hook can result in unnecessary memory allocation if a malicious user sends a large payload in the request body and the request is unauthorized. Fastify will parse the body, even though the request is not authorized, leading to unnecessary memory allocation. To avoid this, use the `onRequest` hook for authentication if the method does not require the request body, such as `@fastify/jwt`, which expects authentication in the request header.
+Using the `@fastify/auth` plugin in the `preHandler` hook can result in unnecessary memory allocation if a malicious user sends a large payload in the request body and the request is unauthorized. Fastify will parse the body, even though the request is not authorized, leading to unnecessary memory allocation. To avoid this, use an `onRequest` or `preParsing` hook for authentication if the method does not require the request body, such as `@fastify/jwt`, which expects authentication in the request header.
 
 For authentication methods that require the request body, such as sending a token in the body, use the `preHandler` hook.
 


### PR DESCRIPTION
This PR updates the security considerations to consider the [`preParsing` hook](https://fastify.dev/docs/latest/Reference/Hooks/#preparsing) safe for auth functionality. The body is not parsed at this stage, so DoS attacks are negated just like they would be with an `onRequest` hook.


Inspired by discussion in https://github.com/fastify/fastify-bearer-auth/pull/207
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
