### PR TITLE
#258 Extended FastifyAuthFunction type to accept async functions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,12 +32,9 @@ declare namespace fastifyAuth {
   export type FastifyAuthFunction<
     Request extends FastifyRequest = FastifyRequest,
     Reply extends FastifyReply = FastifyReply
-  > = (
-    this: FastifyInstance,
-    request: Request,
-    reply: Reply,
-    done: (error?: Error) => void
-  ) => void
+  > =
+    | ((this: FastifyInstance, request: Request, reply: Reply, done: (error?: Error) => void) => void)
+    | ((this: FastifyInstance, request: Request, reply: Reply) => Promise<void>)
 
   /**
    * @link [`fastify-auth` options documentation](https://github.com/fastify/fastify-auth#options)

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -9,13 +9,14 @@ const app = fastify()
 type Done = (error?: Error) => void
 
 app.register(fastifyAuth).after((_err) => {
+  // Callback tests
   app.auth([
     (request, reply, done) => {
       expectType<FastifyRequest>(request)
       expectType<FastifyReply>(reply)
       expectType<Done>(done)
     },
-  ], { relation: 'or' })
+  ], { relation: 'and' })
   app.auth([
     (request, reply, done) => {
       expectType<FastifyRequest>(request)
@@ -29,12 +30,108 @@ app.register(fastifyAuth).after((_err) => {
       expectType<FastifyReply>(reply)
       expectType<Done>(done)
     },
+  ], { relation: 'or', run: 'all' })
+  app.auth([
+    (request, reply, done) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      expectType<Done>(done)
+    },
+  ], { relation: 'and', run: 'all' })
+
+  // Async function tests
+  app.auth([
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
   ])
   app.auth([
-    function () {
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
+  ], { relation: 'and' })
+  app.auth([
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
+  ], { run: 'all' })
+  app.auth([
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
+  ], { relation: 'or', run: 'all' })
+  app.auth([
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
+  ], { relation: 'and', run: 'all' })
+
+  // Promise-based function tests
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ])
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ], { relation: 'and' })
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ], { run: 'all' })
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ], { relation: 'or', run: 'all' })
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ], { relation: 'and', run: 'all' })
+
+  // this context tests
+  app.auth([
+    function (this: FastifyInstance) {
       expectType<FastifyInstance>(this)
     },
   ])
+  app.auth([
+    function (this: FastifyInstance) {
+      expectType<FastifyInstance>(this)
+      return Promise.resolve()
+    },
+  ])
+  app.auth([
+    async function (this: FastifyInstance) {
+      expectType<FastifyInstance>(this)
+      await Promise.resolve()
+    },
+  ])
+
   const auth = app.auth([() => {}])
   expectType<preHandlerHookHandler>(auth)
   app.get('/secret', { preHandler: auth }, () => {})

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -16,6 +16,13 @@ app.register(fastifyAuth).after((_err) => {
       expectType<FastifyReply>(reply)
       expectType<Done>(done)
     },
+  ], { relation: 'or' })
+  app.auth([
+    (request, reply, done) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      expectType<Done>(done)
+    },
   ], { relation: 'and' })
   app.auth([
     (request, reply, done) => {
@@ -53,6 +60,13 @@ app.register(fastifyAuth).after((_err) => {
       expectType<FastifyReply>(reply)
       await Promise.resolve()
     },
+  ], { relation: 'or' })
+  app.auth([
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      await Promise.resolve()
+    },
   ], { relation: 'and' })
   app.auth([
     async (request: FastifyRequest, reply: FastifyReply) => {
@@ -84,6 +98,13 @@ app.register(fastifyAuth).after((_err) => {
       return Promise.resolve()
     },
   ])
+  app.auth([
+    (request: FastifyRequest, reply: FastifyReply) => {
+      expectType<FastifyRequest>(request)
+      expectType<FastifyReply>(reply)
+      return Promise.resolve()
+    },
+  ], { relation: 'or' })
   app.auth([
     (request: FastifyRequest, reply: FastifyReply) => {
       expectType<FastifyRequest>(request)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

All tests are passing:
- [x] Unit tests
- [x] TypeScript tests
- Benchmark script not included, so I couldn't run. 
- Documentation is not changed because of this change is only affect TypeScript type annotation, we can add if needed.

I would like to open a PR for this issue due to contribute if you allow me. 
I've made the the update and updated the tests in this context. Due to TypeScript's inability to automatically infer 'this' context in union types, needed to explicitly specify 'this: FastifyInstance' type annotation in functions that use 'this'. I've updated the tests to reflect this requirement, also added async and promise-based tests to cover the update.

In the function below, which is used without specifying a pre-usable type, the need to use 'this: FastifyInstance' arises due to the situation I mentioned above.

```
app.auth([
    // this should be transform to function (this: FastifyInstance) for TypeScript annotation needs.
    function () { 
      expectType<FastifyInstance>(this)
      return Promise.resolve()
    },
  ])
```
Changes made:
- Updated FastifyAuthFunction type to support both callback and Promise patterns with proper this context
- Added explicit this type annotation in auth tests
- Reorganized test structure for better readability
- tests with { relation: 'or' } added, defaultRelation is already 'or' but defaultRelation definition can be changed.

Please review the changes.
