### PR TITLE
fix(auth): avoid mutating `opts` param in `fastifyAuth`

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -8,8 +8,8 @@ const DEFAULT_RELATION = 'or'
 function fastifyAuth (fastify, opts, next) {
   if (opts.defaultRelation && opts.defaultRelation !== 'or' && opts.defaultRelation !== 'and') {
     return next(new Error("The value of default relation should be one of ['or', 'and']"))
-  }   
-  
+  }
+
   const pluginOptions = {
     defaultRelation: opts.defaultRelation || DEFAULT_RELATION
   }

--- a/auth.js
+++ b/auth.js
@@ -8,11 +8,13 @@ const DEFAULT_RELATION = 'or'
 function fastifyAuth (fastify, opts, next) {
   if (opts.defaultRelation && opts.defaultRelation !== 'or' && opts.defaultRelation !== 'and') {
     return next(new Error("The value of default relation should be one of ['or', 'and']"))
-  } else if (!opts.defaultRelation) {
-    opts.defaultRelation = DEFAULT_RELATION
+  }   
+  
+  const pluginOptions = {
+    defaultRelation: opts.defaultRelation || DEFAULT_RELATION
   }
 
-  fastify.decorate('auth', auth(opts))
+  fastify.decorate('auth', auth(pluginOptions))
   next()
 }
 

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -17,6 +17,20 @@ test('registering plugin with invalid default relation', (t, done) => {
   })
 })
 
+test('registering plugin should not mutate opts', (t, done) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  const opts = {}
+  fastify.register(fastifyAuth, opts)
+
+  fastify.ready((err) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(opts.defaultRelation, undefined)
+    done()
+  })
+})
+
 test('Clean status code through auth pipeline', (t, done) => {
   t.plan(3)
 


### PR DESCRIPTION
The `fastifyAuth` function was mutating the `opts` parameter passed by the caller when setting the default relation. This could cause unexpected side effects for users who reuse the options object.

This change creates a new pluginOptions object with the resolved `defaultRelation` property instead of modifying the original input.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
