### PR TITLE
perf(auth): cache key length properties

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -41,11 +41,13 @@ function auth (pluginOptions) {
       throw new Error('The value of options.run must be \'all\'')
     }
 
-    for (let i = 0; i < functions.length; i++) {
+    const functionsLength = functions.length
+    for (let i = 0; i < functionsLength; i++) {
       if (Array.isArray(functions[i]) === false) {
         functions[i] = functions[i].bind(this)
       } else {
-        for (let j = 0; j < functions[i].length; j++) {
+        const subArrayLength = functions[i].length
+        for (let j = 0; j < subArrayLength; j++) {
           if (Array.isArray(functions[i][j])) {
             throw new TypeError('Nesting sub-arrays is not supported')
           }


### PR DESCRIPTION
Caching the key property is a teeny bit faster as it's not having to do property access.

See https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/loops/_results/results.md

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
